### PR TITLE
Address

### DIFF
--- a/app/controllers/markets_controller.rb
+++ b/app/controllers/markets_controller.rb
@@ -22,7 +22,7 @@ class MarketsController < ApplicationController
     params[:address] = "#{params[:Street]}, #{params[:City]}, #{params[:State]} #{params[:Zip]}"
   end
 
-  def geolocate_by_address 
+  def geolocate_by_address
     location = Geocoder.search(params[:address])
     params[:latitude] = location.first.data['lat']
     params[:longitude] = location.first.data['lon']

--- a/app/controllers/markets_controller.rb
+++ b/app/controllers/markets_controller.rb
@@ -7,7 +7,9 @@ class MarketsController < ApplicationController
       @markets = MarketFacade.new(params).all_markets
     else
       address_format
-      geolocate_by_address
+      coordinates = CoordinatesFacade.new(params[:address]).coordiantes
+      params[:latitude] = coordinates[0].latitude
+      params[:longitude] = coordinates[0].longitude
       @markets = MarketFacade.new(params).all_markets
     end
   end
@@ -19,12 +21,6 @@ class MarketsController < ApplicationController
   private
 
   def address_format
-    params[:address] = "#{params[:Street]}, #{params[:City]}, #{params[:State]} #{params[:Zip]}"
-  end
-
-  def geolocate_by_address
-    location = Geocoder.search(params[:address])
-    params[:latitude] = location.first.data['lat']
-    params[:longitude] = location.first.data['lon']
+    params[:address] = "#{params[:street]}, #{params[:city]}, #{params[:state]} #{params[:zipcode]}"
   end
 end

--- a/app/controllers/markets_controller.rb
+++ b/app/controllers/markets_controller.rb
@@ -6,7 +6,8 @@ class MarketsController < ApplicationController
     if params[:latitude] != "" && params[:longitude] != ""
       @markets = MarketFacade.new(params).all_markets
     else
-      geolocate_by_zip
+      address_format
+      geolocate_by_address
       @markets = MarketFacade.new(params).all_markets
     end
   end
@@ -17,8 +18,12 @@ class MarketsController < ApplicationController
 
   private
 
-  def geolocate_by_zip 
-    location = Geocoder.search(params[:zip])
+  def address_format
+    params[:address] = "#{params[:Street]}, #{params[:City]}, #{params[:State]} #{params[:Zip]}"
+  end
+
+  def geolocate_by_address 
+    location = Geocoder.search(params[:address])
     params[:latitude] = location.first.data['lat']
     params[:longitude] = location.first.data['lon']
   end

--- a/app/controllers/markets_controller.rb
+++ b/app/controllers/markets_controller.rb
@@ -7,7 +7,7 @@ class MarketsController < ApplicationController
       @markets = MarketFacade.new(params).all_markets
     else
       address_format
-      coordinates = CoordinatesFacade.new(params[:address]).coordiantes
+      coordinates = CoordinatesFacade.new(params[:address]).coordinates
       params[:latitude] = coordinates[0].latitude
       params[:longitude] = coordinates[0].longitude
       @markets = MarketFacade.new(params).all_markets

--- a/app/facades/coordinates_facade.rb
+++ b/app/facades/coordinates_facade.rb
@@ -1,0 +1,17 @@
+class CoordinatesFacade
+  attr_reader :address
+  def initialize(params)
+    @address = params
+  end
+  
+  def coordiantes
+    service.coordinates(@address)[:results].map do |data|
+      Coordinate.new(data)
+    end
+  end
+
+  def service
+    CoordinatesService.new
+  end
+
+end

--- a/app/facades/coordinates_facade.rb
+++ b/app/facades/coordinates_facade.rb
@@ -4,7 +4,7 @@ class CoordinatesFacade
     @address = params
   end
   
-  def coordiantes
+  def coordinates
     service.coordinates(@address)[:results].map do |data|
       Coordinate.new(data)
     end

--- a/app/poros/coordinate.rb
+++ b/app/poros/coordinate.rb
@@ -1,0 +1,7 @@
+class Coordinate
+  attr_reader :latitude, :longitude
+  def initialize(attributes)
+    @latitude = attributes[:geometry][:location][:lat]
+    @longitude = attributes[:geometry][:location][:lng]
+  end
+end

--- a/app/services/coordinates_service.rb
+++ b/app/services/coordinates_service.rb
@@ -1,0 +1,14 @@
+class CoordinatesService
+  def conn
+    Faraday.new(url: "https://maps.googleapis.com/maps/api/geocode/json")
+  end
+
+  def get_url(url)
+    response = conn.get(url)
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  def coordinates(address)
+    get_url("?address=#{address}&key=#{Figaro.env.maps_api}")
+  end
+end

--- a/app/views/markets/search.html.erb
+++ b/app/views/markets/search.html.erb
@@ -62,9 +62,27 @@ function getLocation() {
   <%= f.hidden_field :longitude, id: "longitude-field" %>
 
 <div class="container">
-  <h6 class="text-center"><%= f.label :zip, "Zipcode:" %></h6>
+
   <div class="d-grid justify-content-center">
-    <%= f.text_field :zip %>
+    <h6 class="text-inline">
+      <%= f.label :Street, "Street:" %> <br> 
+    </h6>
+    <%= f.text_field :Street  %> <br>
+
+    <h6 class="text-inline">
+      <%= f.label :City, "City:" %> <br> 
+    </h6>
+    <%= f.text_field :City %> <br>
+
+    <h6 class="text-inline">
+      <%= f.label :State, "State:" %> <br> 
+    </h6>
+    <%= f.text_field :State %> <br>
+
+    <h6 class="text-inline">
+      <%= f.label :Zip, "Zipcode:" %> <br> 
+    </h6>
+    <%= f.text_field :Zip %> <br>
   </div>
 </div><br><br>
 

--- a/app/views/markets/search.html.erb
+++ b/app/views/markets/search.html.erb
@@ -95,7 +95,7 @@ function getLocation() {
 
 <script>
   const checkBox = document.getElementById("location");
-  const address = document.getElementById("address");
+  const address = document.getElementById("street");
   const city = document.getElementById("city");
   const state = document.getElementById("state");
   const zipcode = document.getElementById("zipcode");

--- a/app/views/markets/search.html.erb
+++ b/app/views/markets/search.html.erb
@@ -64,7 +64,7 @@ function getLocation() {
   <div class="row text-center py-3 mt-3">
     <div class="col-4 mx-auto">
       <div class="input-group input-group-static">
-        <input class="form-control" placeholder="Street address" type="text" id="address">
+        <%= f.text_field :street, {class:"form-control", placeholder:"Street Address", type:"text", id:"street"} %>
       </div>
     </div>
   </div>
@@ -72,7 +72,7 @@ function getLocation() {
   <div class="row text-center py-3 mt-3">
     <div class="col-4 mx-auto">
       <div class="input-group input-group-static">
-        <input class="form-control" placeholder="City" type="text" id="city">
+        <%= f.text_field :city, {class:"form-control", placeholder:"City", type:"text", id:"city"} %>
       </div>
     </div>
   </div>
@@ -80,14 +80,14 @@ function getLocation() {
   <div class="row text-center py-3 mt-3">
     <div class="col-4 mx-auto">
       <div class="input-group input-group-static">
-        <input class="form-control" placeholder="State" type="text" id="state">
+        <%= f.text_field :state, {class:"form-control", placeholder:"State", type:"text", id:"state"} %>
       </div>
     </div>
   </div>
   <div class="row text-center py-3 mt-3">
     <div class="col-4 mx-auto">
       <div class="input-group input-group-static">
-        <input class="form-control" placeholder="Zipcode" type="text" id="zipcode">
+        <%= f.text_field :zipcode, {class:"form-control", placeholder:"Zipcode", type:"text", id:"zipcode"} %>
       </div>
     </div>
   </div>

--- a/app/views/markets/search.html.erb
+++ b/app/views/markets/search.html.erb
@@ -4,17 +4,18 @@
       Find a Market
     </h1>
   </div>
-</div><br><br>
+</div><br>
 
-<div class="container">
-  <div class="row">
-    <div class="d-grid">
-      <button class="btn btn-info" style="background-color: rgba(0, 159, 183, 1)" id="location">
-              Use My Location
-      </button>
+<div class="container py-3 mt-3">
+<div class="row">
+  <div class="col-4 mx-auto d-grid justify-content-center">
+    <div class="form-check form-switch ps-0">
+      <input class="form-check-input ms-auto mt-1" type="checkbox" id="location" onClick="disableInput()">
+      <label class="form-check-label ms-2" for="flexSwitchCheckDefault">Use My Location</label>
     </div>
   </div>
-</div><br>
+</div>
+</div>
 
 <div class="d-flex justify-content-center">
   <div class="spinner-grow text-warning" role="status" style="display: none" id ="spinner" >
@@ -60,31 +61,58 @@ function getLocation() {
 <%= form_with url: markets_path, method: :get do |f| %>
   <%= f.hidden_field :latitude, id: 'latitude-field'  %>
   <%= f.hidden_field :longitude, id: "longitude-field" %>
-
-<div class="container">
-
-  <div class="d-grid justify-content-center">
-    <h6 class="text-inline">
-      <%= f.label :Street, "Street:" %> <br> 
-    </h6>
-    <%= f.text_field :Street  %> <br>
-
-    <h6 class="text-inline">
-      <%= f.label :City, "City:" %> <br> 
-    </h6>
-    <%= f.text_field :City %> <br>
-
-    <h6 class="text-inline">
-      <%= f.label :State, "State:" %> <br> 
-    </h6>
-    <%= f.text_field :State %> <br>
-
-    <h6 class="text-inline">
-      <%= f.label :Zip, "Zipcode:" %> <br> 
-    </h6>
-    <%= f.text_field :Zip %> <br>
+  <div class="row text-center py-3 mt-3">
+    <div class="col-4 mx-auto">
+      <div class="input-group input-group-static">
+        <input class="form-control" placeholder="Street address" type="text" id="address">
+      </div>
+    </div>
   </div>
-</div><br><br>
+  <br>
+  <div class="row text-center py-3 mt-3">
+    <div class="col-4 mx-auto">
+      <div class="input-group input-group-static">
+        <input class="form-control" placeholder="City" type="text" id="city">
+      </div>
+    </div>
+  </div>
+  <br>
+  <div class="row text-center py-3 mt-3">
+    <div class="col-4 mx-auto">
+      <div class="input-group input-group-static">
+        <input class="form-control" placeholder="State" type="text" id="state">
+      </div>
+    </div>
+  </div>
+  <div class="row text-center py-3 mt-3">
+    <div class="col-4 mx-auto">
+      <div class="input-group input-group-static">
+        <input class="form-control" placeholder="Zipcode" type="text" id="zipcode">
+      </div>
+    </div>
+  </div>
+  <br>
+
+<script>
+  const checkBox = document.getElementById("location");
+  const address = document.getElementById("address");
+  const city = document.getElementById("city");
+  const state = document.getElementById("state");
+  const zipcode = document.getElementById("zipcode");
+  checkBox.addEventListener("change", (event) => {
+    if (event.currentTarget.checked == true) {
+      address.disabled = true;
+      city.disabled = true;
+      state.disabled = true;
+      zipcode.disabled = true;
+    } else {
+      address.disabled = false;
+      city.disabled = false;
+      state.disabled = false;
+      zipcode.disabled = false;
+    }
+  })
+</script>
 
 <div class="container">
   <h6 class="text-center"><%= f.label :radius, "Keep Search Within (miles):" %></h6>
@@ -93,11 +121,11 @@ function getLocation() {
       <%= f.select :radius, [1, 10, 25, 50] %>
     </div>
   </div>
-</div><br><br>
+</div><br>
 
 <div class="container">
-  <div class="d-grid">
-  <%= f.submit "Find Markets", class:  "btn btn-info", style: "background-color: rgba(0, 159, 183, 1)"%>
+  <div class="d-grid justify-content-center">
+    <%= f.submit "Find Markets", class: "btn btn-info" %>
   </div>
 </div>
 <% end %>

--- a/spec/facades/coordinates_spec.rb
+++ b/spec/facades/coordinates_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe CoordinatesFacade, type: :model do
+  describe "#coordinates" do
+    it "can return coordinates by address", :vcr do 
+      address = "6715 W Colfax Ave, Lakewood, CO 80214"
+      coordinates = CoordinatesFacade.new(address).coordinates
+      expect(coordinates[0]).to be_a(Object)
+      expect(coordinates[0].latitude).to eq(39.7417639)
+      expect(coordinates[0].longitude).to eq(-105.070705)
+    end
+  end
+end

--- a/spec/features/markets/search_spec.rb
+++ b/spec/features/markets/search_spec.rb
@@ -35,9 +35,12 @@ RSpec.describe "Search for markets" do
       expect(markets.first[:attributes][:name]).to eq("Market in The Park")
       expect(markets.second[:attributes][:name]).to eq("Market in The Park - Lavretta Park")
     end
-    it "can search for markets by zip" do
+    it "can search for markets by address" do
       visit markets_search_path
-      fill_in :zip, with: 80041
+      fill_in :Street, with:  "6715 W Colfax Ave"
+      fill_in :City, with: "Lakewood"
+      fill_in :State, with: "CO"
+      fill_in :Zip, with: 80041
       select "10", from: "radius"
       click_on "Find Markets"
     end
@@ -58,14 +61,20 @@ RSpec.describe "Search for markets" do
         expect(page).to have_content("Keep Search Within (miles):")
         expect(page).to have_field(:radius)
         expect(page).to have_button("Find Markets")
-        expect(page).to have_field(:zip)
+        expect(page).to have_field(:Street)
+        expect(page).to have_field(:City)
+        expect(page).to have_field(:State)
+        expect(page).to have_field(:Zip)
+        expect(page).to have_content("Street")
+        expect(page).to have_content("City")
+        expect(page).to have_content("State")
         expect(page).to have_content("Zipcode")
       end
     end
     
     describe 'usability' do
-      it 'geolocates based on zipcode' do 
-        visit "/markets?zip=80111&radius=50"
+      it 'geolocates based on address' do 
+        visit "/markets?address=6715 W Colfax Ave, Lakewood, CO 80214&radius=50"
 
         expect(current_path).to eq(markets_path)
       end

--- a/spec/features/markets/search_spec.rb
+++ b/spec/features/markets/search_spec.rb
@@ -35,16 +35,15 @@ RSpec.describe "Search for markets" do
       expect(markets.first[:attributes][:name]).to eq("Market in The Park")
       expect(markets.second[:attributes][:name]).to eq("Market in The Park - Lavretta Park")
     end
-    it "can search for markets by address" do
+    xit "can search for markets by address" do
       visit markets_search_path
-      fill_in :Street, with:  "6715 W Colfax Ave"
-      fill_in :City, with: "Lakewood"
-      fill_in :State, with: "CO"
-      fill_in :Zip, with: 80041
+      fill_in "address", with:  "6715 W Colfax Ave"
+      fill_in "City", with: "Lakewood"
+      fill_in "State", with: "CO"
+      fill_in "Zipcode", with: 80041
       select "10", from: "radius"
       click_on "Find Markets"
     end
-
   end
 
   describe 'geolocation' do 
@@ -54,21 +53,17 @@ RSpec.describe "Search for markets" do
 
     describe 'contents' do 
       it 'Use My Location button' do 
-        expect(page).to have_button("Use My Location")
+        expect(page).to have_content("Use My Location")
       end
 
       it 'has form elements' do 
         expect(page).to have_content("Keep Search Within (miles):")
         expect(page).to have_field(:radius)
         expect(page).to have_button("Find Markets")
-        expect(page).to have_field(:Street)
+        expect(page).to have_field(:address)
         expect(page).to have_field(:City)
         expect(page).to have_field(:State)
-        expect(page).to have_field(:Zip)
-        expect(page).to have_content("Street")
-        expect(page).to have_content("City")
-        expect(page).to have_content("State")
-        expect(page).to have_content("Zipcode")
+        expect(page).to have_field(:Zipcode)
       end
     end
     

--- a/spec/features/markets/search_spec.rb
+++ b/spec/features/markets/search_spec.rb
@@ -35,9 +35,9 @@ RSpec.describe "Search for markets" do
       expect(markets.first[:attributes][:name]).to eq("Market in The Park")
       expect(markets.second[:attributes][:name]).to eq("Market in The Park - Lavretta Park")
     end
-    xit "can search for markets by address" do
+    it "can search for markets by address" do
       visit markets_search_path
-      fill_in "address", with:  "6715 W Colfax Ave"
+      fill_in "street", with:  "6715 W Colfax Ave"
       fill_in "City", with: "Lakewood"
       fill_in "State", with: "CO"
       fill_in "Zipcode", with: 80041
@@ -60,7 +60,7 @@ RSpec.describe "Search for markets" do
         expect(page).to have_content("Keep Search Within (miles):")
         expect(page).to have_field(:radius)
         expect(page).to have_button("Find Markets")
-        expect(page).to have_field(:address)
+        expect(page).to have_field(:street)
         expect(page).to have_field(:City)
         expect(page).to have_field(:State)
         expect(page).to have_field(:Zipcode)

--- a/spec/fixtures/vcr_cassettes/CoordinatesFacade/_coordinates/can_return_coordinates_by_address.yml
+++ b/spec/fixtures/vcr_cassettes/CoordinatesFacade/_coordinates/can_return_coordinates_by_address.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://maps.googleapis.com/maps/api/geocode/json?address=6715%20W%20Colfax%20Ave,%20Lakewood,%20CO%2080214&key=AIzaSyAWqH7Rw6M7A3RIZ3u5UWPNegY6aiQkuCg
+    uri: https://maps.googleapis.com/maps/api/geocode/json?address=6715%20W%20Colfax%20Ave,%20Lakewood,%20CO%2080214&key=Hide_API
     body:
       encoding: US-ASCII
       string: ''
@@ -21,7 +21,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 18 Aug 2023 18:52:09 GMT
+      - Fri, 18 Aug 2023 18:58:12 GMT
       Pragma:
       - no-cache
       Expires:
@@ -43,7 +43,7 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Server-Timing:
-      - gfet4t7; dur=106
+      - gfet4t7; dur=64
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
     body:
@@ -86,5 +86,5 @@ http_interactions:
         : -105.0719534302915\n               }\n            }\n         },\n         \"place_id\"
         : \"ChIJCc2cfCSHa4cRn3dXFexwXvM\",\n         \"types\" : \n         [\n            \"subpremise\"\n
         \        ]\n      }\n   ],\n   \"status\" : \"OK\"\n}"
-  recorded_at: Fri, 18 Aug 2023 18:52:09 GMT
+  recorded_at: Fri, 18 Aug 2023 18:58:12 GMT
 recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/CoordinatesFacade/_coordinates/can_return_coordinates_by_address.yml
+++ b/spec/fixtures/vcr_cassettes/CoordinatesFacade/_coordinates/can_return_coordinates_by_address.yml
@@ -1,0 +1,90 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://maps.googleapis.com/maps/api/geocode/json?address=6715%20W%20Colfax%20Ave,%20Lakewood,%20CO%2080214&key=AIzaSyAWqH7Rw6M7A3RIZ3u5UWPNegY6aiQkuCg
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.7.10
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 18 Aug 2023 18:52:09 GMT
+      Pragma:
+      - no-cache
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - no-cache, must-revalidate
+      Vary:
+      - Accept-Language
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Goog-Maps-Metro-Area:
+      - Denver, CO
+      Server:
+      - mafe
+      Content-Length:
+      - '2913'
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=106
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+    body:
+      encoding: UTF-8
+      string: "{\n   \"results\" : \n   [\n      {\n         \"address_components\"
+        : \n         [\n            {\n               \"long_name\" : \"6715\",\n
+        \              \"short_name\" : \"6715\",\n               \"types\" : \n               [\n
+        \                 \"street_number\"\n               ]\n            },\n            {\n
+        \              \"long_name\" : \"West Colfax Avenue\",\n               \"short_name\"
+        : \"W Colfax Ave\",\n               \"types\" : \n               [\n                  \"route\"\n
+        \              ]\n            },\n            {\n               \"long_name\"
+        : \"Edgewood\",\n               \"short_name\" : \"Edgewood\",\n               \"types\"
+        : \n               [\n                  \"neighborhood\",\n                  \"political\"\n
+        \              ]\n            },\n            {\n               \"long_name\"
+        : \"Lakewood\",\n               \"short_name\" : \"Lakewood\",\n               \"types\"
+        : \n               [\n                  \"locality\",\n                  \"political\"\n
+        \              ]\n            },\n            {\n               \"long_name\"
+        : \"Jefferson County\",\n               \"short_name\" : \"Jefferson County\",\n
+        \              \"types\" : \n               [\n                  \"administrative_area_level_2\",\n
+        \                 \"political\"\n               ]\n            },\n            {\n
+        \              \"long_name\" : \"Colorado\",\n               \"short_name\"
+        : \"CO\",\n               \"types\" : \n               [\n                  \"administrative_area_level_1\",\n
+        \                 \"political\"\n               ]\n            },\n            {\n
+        \              \"long_name\" : \"United States\",\n               \"short_name\"
+        : \"US\",\n               \"types\" : \n               [\n                  \"country\",\n
+        \                 \"political\"\n               ]\n            },\n            {\n
+        \              \"long_name\" : \"80214\",\n               \"short_name\" :
+        \"80214\",\n               \"types\" : \n               [\n                  \"postal_code\"\n
+        \              ]\n            },\n            {\n               \"long_name\"
+        : \"1807\",\n               \"short_name\" : \"1807\",\n               \"types\"
+        : \n               [\n                  \"postal_code_suffix\"\n               ]\n
+        \           }\n         ],\n         \"formatted_address\" : \"6715 W Colfax
+        Ave, Lakewood, CO 80214, USA\",\n         \"geometry\" : \n         {\n            \"location\"
+        : \n            {\n               \"lat\" : 39.7417639,\n               \"lng\"
+        : -105.070705\n            },\n            \"location_type\" : \"ROOFTOP\",\n
+        \           \"viewport\" : \n            {\n               \"northeast\" :
+        \n               {\n                  \"lat\" : 39.74303158029149,\n                  \"lng\"
+        : -105.0692554697085\n               },\n               \"southwest\" : \n
+        \              {\n                  \"lat\" : 39.74033361970849,\n                  \"lng\"
+        : -105.0719534302915\n               }\n            }\n         },\n         \"place_id\"
+        : \"ChIJCc2cfCSHa4cRn3dXFexwXvM\",\n         \"types\" : \n         [\n            \"subpremise\"\n
+        \        ]\n      }\n   ],\n   \"status\" : \"OK\"\n}"
+  recorded_at: Fri, 18 Aug 2023 18:52:09 GMT
+recorded_with: VCR 6.2.0

--- a/spec/poros/coordinate_poros_spec.rb
+++ b/spec/poros/coordinate_poros_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Coordinate, type: :poro do
+  it 'can be initialized with data' do
+    data = {
+      geometry: {
+        location: {
+        lat: 39.7418,
+        lng: -105.0708
+      }
+      }
+    }
+
+    coordinates = Coordinate.new(data)
+    expect(coordinates.latitude).to be_a(Float)
+    expect(coordinates.latitude).to eq(39.7418)
+    expect(coordinates.longitude).to be_a(Float)
+    expect(coordinates.longitude).to eq(-105.0708)
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -76,6 +76,7 @@ RSpec.configure do |config|
 end
 VCR.configure do |config|
   config.cassette_library_dir = 'spec/fixtures/vcr_cassettes'
+  config.filter_sensitive_data("Hide_API") {ENV["MAPS_API"]}
   config.hook_into :webmock
   config.configure_rspec_metadata!
   config.allow_http_connections_when_no_cassette = true

--- a/spec/services/coordinate_service_spec.rb
+++ b/spec/services/coordinate_service_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe CoordinatesService do
+  let(:coordinates_service) { CoordinatesService.new }
+
+  describe '#coordinates' do
+    it 'fetches coordinates for address' do
+
+      address = "6715 W Colfax Ave, Lakewood, CO 80214"
+
+      stub_request(:get, "https://maps.googleapis.com/maps/api/geocode/json?address=#{address}")
+        .to_return(status: 200, body: '{"geometry"{"location"{"lat": 39.7418, "lng": -105.0708}}}', headers: { 'Content-Type' => 'application/json' })
+      response = coordinates_service.coordinates(address)
+
+      expect(response).to be_an(Hash)
+      expect(response[:results][0][:geometry]).to have_key(:location)
+      expect(response[:results][0][:geometry][:location]).to have_key(:lat)
+      expect(response[:results][0][:geometry][:location]).to have_key(:lng)
+    end
+  end
+end
+


### PR DESCRIPTION
This patches the search for markets form to use an address instead of just a zipcode
Adds method to markets controller that strings together the address so that it can be geocoded for coordinates